### PR TITLE
Support for processing activation links when the app is closed (iOS)

### DIFF
--- a/lib/firebase_email_link_handler.dart
+++ b/lib/firebase_email_link_handler.dart
@@ -4,7 +4,6 @@ import 'package:flutter/services.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:meta/meta.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:rxdart/rxdart.dart';
 
 class FirebaseEmailLinkHandler {
   final SharedPreferences sharedPreferences;
@@ -18,8 +17,8 @@ class FirebaseEmailLinkHandler {
 
   Stream<String> get channelStream => channel.receiveBroadcastStream().map((event) => event as String);
 
-  BehaviorSubject<String> _errorController = BehaviorSubject<String>();
-  Observable<String> get errorStream => _errorController.stream;
+  StreamController<String> _errorController = StreamController<String>();
+  Stream<String> get errorStream => _errorController.stream;
 
   FirebaseEmailLinkHandler({@required this.channel, @required this.sharedPreferences}) {
     _subscription = channelStream.listen((String event) async {

--- a/lib/landing_page.dart
+++ b/lib/landing_page.dart
@@ -1,12 +1,42 @@
 
+import 'dart:async';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:passwordless/firebase_email_link_handler.dart';
 import 'package:passwordless/home_page.dart';
+import 'package:passwordless/platform_alert_dialog.dart';
 import 'package:passwordless/sign_in_page.dart';
 
-class LandingPage extends StatelessWidget {
-  final linkHandler = FirebaseEmailLinkHandler();
+class LandingPage extends StatefulWidget {
+  final FirebaseEmailLinkHandler linkHandler;
+  LandingPage({Key key, this.linkHandler}) : super(key: key);
+
+  @override
+  LandingPageState createState() => LandingPageState();
+}
+
+class LandingPageState extends State<LandingPage> {
+
+  StreamSubscription _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscription = widget.linkHandler.errorStream.listen((error) {
+      PlatformAlertDialog(
+        title: "Email activation error",
+        content: error,
+        defaultActionText: "Dismiss",
+      ).show(context);
+    });
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -17,7 +47,7 @@ class LandingPage extends StatelessWidget {
           if (snapshot.hasData) {
             return HomePage(user: snapshot.data);
           } else {
-            return SignInPage(linkHandler: linkHandler);
+            return SignInPage(linkHandler: widget.linkHandler);
           }
         } else {
           return Scaffold(

--- a/lib/landing_page.dart
+++ b/lib/landing_page.dart
@@ -34,6 +34,7 @@ class LandingPageState extends State<LandingPage> {
 
   @override
   void dispose() {
+    widget.linkHandler.dispose();
     _subscription?.cancel();
     super.dispose();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,6 @@ void main() async {
 class MyApp extends StatelessWidget {
   const MyApp({Key key, this.sharedPreferences}) : super(key: key);
   final SharedPreferences sharedPreferences;
-  static final channel = EventChannel('linkHandler');
 
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -22,7 +21,6 @@ class MyApp extends StatelessWidget {
       home: LandingPage(
         linkHandler: FirebaseEmailLinkHandler(
           sharedPreferences: sharedPreferences,
-          channel: channel,
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:passwordless/firebase_email_link_handler.dart';
 import 'package:passwordless/landing_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-void main() => runApp(MyApp());
+void main() async {
+  runApp(MyApp(sharedPreferences: await SharedPreferences.getInstance()));
+}
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key key, this.sharedPreferences}) : super(key: key);
+  final SharedPreferences sharedPreferences;
+  static final channel = EventChannel('linkHandler');
 
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -11,10 +19,12 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: LandingPage(),
+      home: LandingPage(
+        linkHandler: FirebaseEmailLinkHandler(
+          sharedPreferences: sharedPreferences,
+          channel: channel,
+        ),
+      ),
     );
   }
 }
-
-
-

--- a/lib/sign_in_page.dart
+++ b/lib/sign_in_page.dart
@@ -69,6 +69,7 @@ class _SignInPageState extends State<SignInPage> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           TextFormField(
+            initialValue: widget.linkHandler.email,
             decoration: InputDecoration(
               hintText: 'Email Address',
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ environment:
 
 dependencies:
   shared_preferences: 0.5.0
+  rxdart: any
   firebase_auth:
     git:
       url: https://github.com/bizz84/plugins

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,6 @@ environment:
 
 dependencies:
   shared_preferences: 0.5.0
-  rxdart: any
   firebase_auth:
     git:
       url: https://github.com/bizz84/plugins


### PR DESCRIPTION
- [x] Queue email links until EventChannel is properly initialized.
- [x] Print any activation errors in the app